### PR TITLE
feat: 添加预览与导出图片阴影开关

### DIFF
--- a/wj-markdown-editor-electron/src/data/config/__tests__/configLoadSanitizer.test.js
+++ b/wj-markdown-editor-electron/src/data/config/__tests__/configLoadSanitizer.test.js
@@ -165,11 +165,13 @@ describe('configLoadSanitizer', () => {
     const loadedConfig = cloneConfig(defaultConfig)
     delete loadedConfig.markdown.inlineCodeClickCopy
     loadedConfig.markdown.typographer = false
+    loadedConfig.markdown.imageShadow = false
 
     const sanitized = sanitizeLoadedConfig(loadedConfig, defaultConfig, configSchema)
 
     expect(sanitized.markdown.inlineCodeClickCopy).toBe(false)
     expect(sanitized.markdown.typographer).toBe(false)
+    expect(sanitized.markdown.imageShadow).toBe(false)
   })
 
   it('markdown.inlineCodeClickCopy 非法时必须仅回退该字段', () => {
@@ -179,10 +181,37 @@ describe('configLoadSanitizer', () => {
         ...cloneConfig(defaultConfig.markdown),
         inlineCodeClickCopy: 'invalid',
         typographer: false,
+        imageShadow: false,
       },
     }, defaultConfig, configSchema)
 
     expect(sanitized.markdown.inlineCodeClickCopy).toBe(false)
+    expect(sanitized.markdown.typographer).toBe(false)
+    expect(sanitized.markdown.imageShadow).toBe(false)
+  })
+
+  it('markdown.imageShadow 缺失时必须补默认值，且同层其他合法字段保持原值', () => {
+    const loadedConfig = cloneConfig(defaultConfig)
+    delete loadedConfig.markdown.imageShadow
+    loadedConfig.markdown.typographer = false
+
+    const sanitized = sanitizeLoadedConfig(loadedConfig, defaultConfig, configSchema)
+
+    expect(sanitized.markdown.imageShadow).toBe(true)
+    expect(sanitized.markdown.typographer).toBe(false)
+  })
+
+  it('markdown.imageShadow 非法时必须仅回退该字段', () => {
+    const sanitized = sanitizeLoadedConfig({
+      ...cloneConfig(defaultConfig),
+      markdown: {
+        ...cloneConfig(defaultConfig.markdown),
+        imageShadow: 'invalid',
+        typographer: false,
+      },
+    }, defaultConfig, configSchema)
+
+    expect(sanitized.markdown.imageShadow).toBe(true)
     expect(sanitized.markdown.typographer).toBe(false)
   })
 

--- a/wj-markdown-editor-electron/src/data/config/__tests__/configMutationSchema.test.js
+++ b/wj-markdown-editor-electron/src/data/config/__tests__/configMutationSchema.test.js
@@ -31,6 +31,7 @@ describe('validateConfigMutationRequest', () => {
     [['editorExtension', 'highlightSelectionMatches'], false],
     [['editorExtension', 'bracketMatching'], false],
     [['editorExtension', 'closeBrackets'], false],
+    [['markdown', 'imageShadow'], false],
     [['imageBed', 'uploader'], 'smms'],
     [['imageBed', 'smms', 'token'], 'token'],
     [['imageBed', 'smms', 'backupDomain'], 'smms.app'],

--- a/wj-markdown-editor-electron/src/data/config/__tests__/configRepairUtil.test.js
+++ b/wj-markdown-editor-electron/src/data/config/__tests__/configRepairUtil.test.js
@@ -38,6 +38,17 @@ describe('configRepairUtil', () => {
     })
   })
 
+  it('缺失 markdown.imageShadow 时必须从默认配置补齐', () => {
+    const legacyConfig = JSON.parse(JSON.stringify(defaultConfig))
+    delete legacyConfig.markdown.imageShadow
+    legacyConfig.markdown.typographer = false
+
+    const repaired = repairConfig(legacyConfig, defaultConfig)
+
+    expect(repaired.markdown.imageShadow).toBe(true)
+    expect(repaired.markdown.typographer).toBe(false)
+  })
+
   it('默认配置中不存在的旧字段必须被裁掉', () => {
     const repaired = repairConfig({
       legacyField: 'deprecated',

--- a/wj-markdown-editor-electron/src/data/config/__tests__/configSchema.test.js
+++ b/wj-markdown-editor-electron/src/data/config/__tests__/configSchema.test.js
@@ -12,6 +12,10 @@ describe('configSchema', () => {
     expect(defaultConfig.markdown.inlineCodeClickCopy).toBe(false)
   })
 
+  it('defaultConfig 必须提供 markdown.imageShadow 默认值 true', () => {
+    expect(defaultConfig.markdown.imageShadow).toBe(true)
+  })
+
   it('defaultConfig 必须提供 fileManagerVisible 默认值 true', () => {
     expect(defaultConfig.fileManagerVisible).toBe(true)
   })
@@ -175,6 +179,18 @@ describe('configSchema', () => {
       markdown: {
         ...defaultConfig.markdown,
         inlineCodeClickCopy: true,
+      },
+    }
+
+    expect(() => validateConfigShape(validConfig)).not.toThrow()
+  })
+
+  it('markdown.imageShadow 接纳布尔值 false', () => {
+    const validConfig = {
+      ...defaultConfig,
+      markdown: {
+        ...defaultConfig.markdown,
+        imageShadow: false,
       },
     }
 

--- a/wj-markdown-editor-electron/src/data/config/configMutationSchema.js
+++ b/wj-markdown-editor-electron/src/data/config/configMutationSchema.js
@@ -27,6 +27,7 @@ const SET_PATH_SET = new Set([
   'editorExtension.closeBrackets',
   'markdown.typographer',
   'markdown.inlineCodeClickCopy',
+  'markdown.imageShadow',
   'externalFileChangeStrategy',
   'startPage',
   'openRecent',

--- a/wj-markdown-editor-electron/src/data/config/configSchema.js
+++ b/wj-markdown-editor-electron/src/data/config/configSchema.js
@@ -16,10 +16,11 @@ const fontFamilySchema = {
 const markdownSchema = {
   type: 'object',
   additionalProperties: false,
-  required: ['typographer', 'inlineCodeClickCopy'],
+  required: ['typographer', 'inlineCodeClickCopy', 'imageShadow'],
   properties: {
     typographer: { type: 'boolean' },
     inlineCodeClickCopy: { type: 'boolean' },
+    imageShadow: { type: 'boolean' },
   },
 }
 

--- a/wj-markdown-editor-electron/src/data/defaultConfig.js
+++ b/wj-markdown-editor-electron/src/data/defaultConfig.js
@@ -36,6 +36,7 @@ export default {
   markdown: {
     typographer: true,
     inlineCodeClickCopy: false,
+    imageShadow: true,
   },
   export: {
     pdf: {

--- a/wj-markdown-editor-web/src/components/editor/MarkdownPreview.vue
+++ b/wj-markdown-editor-web/src/components/editor/MarkdownPreview.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { message } from 'ant-design-vue'
 import mermaid from 'mermaid'
-import { nextTick, onActivated, onBeforeUnmount, onDeactivated, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onActivated, onBeforeUnmount, onDeactivated, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { onBeforeRouteLeave } from 'vue-router'
 import { shouldReplaceElementBeforeAttributeSync } from '@/components/editor/markdownPreviewDomPatchUtil.js'
@@ -70,7 +70,7 @@ function initMermaid() {
 
 const previewRef = ref()
 
-const previewShellStyle = {
+const previewShellStyle = computed(() => ({
   'fontFamily': 'var(--preview-area-font)',
   // 在样式层完成新旧变量名桥接，避免把兼容逻辑扩散到 helper 内部。
   '--wj-code-block-action-color': 'var(--wj-code-block-action-fg-muted)',
@@ -79,7 +79,8 @@ const previewShellStyle = {
   '--wj-code-block-action-focus-border-color': 'var(--wj-code-block-action-border)',
   '--wj-code-block-action-background': 'var(--wj-code-block-action-bg)',
   '--wj-code-block-action-focus-background': 'var(--wj-code-block-action-bg)',
-}
+  '--wj-preview-image-box-shadow': store.config.markdown?.imageShadow === false ? 'none' : 'var(--img-box-shadow)',
+}))
 
 const imageSrcList = ref([])
 const imagePreviewVisible = ref(false)

--- a/wj-markdown-editor-web/src/components/editor/__tests__/markdownPreviewContextMenuRuntime.vitest.test.js
+++ b/wj-markdown-editor-web/src/components/editor/__tests__/markdownPreviewContextMenuRuntime.vitest.test.js
@@ -15,6 +15,7 @@ const markdownPreviewRuntimeState = vi.hoisted(() => ({
       },
       markdown: {
         inlineCodeClickCopy: false,
+        imageShadow: true,
         typographer: false,
       },
     },
@@ -196,6 +197,7 @@ async function flushPreviewRender() {
 
 describe('markdownPreview runtime contextmenu', () => {
   beforeEach(() => {
+    markdownPreviewRuntimeState.store.config.markdown.imageShadow = true
     markdownPreviewRuntimeState.mdRender.mockImplementation(() => markdownPreviewRuntimeState.renderedHtml)
     markdownPreviewRuntimeState.renderedHtml = [
       '<p data-line-start="3" data-line-end="3">',
@@ -245,6 +247,26 @@ describe('markdownPreview runtime contextmenu', () => {
         y: 260,
       },
     })
+  })
+
+  it('图片阴影开启时预览根节点应沿用主题阴影变量', async () => {
+    markdownPreviewRuntimeState.store.config.markdown.imageShadow = true
+
+    const wrapper = mountMarkdownPreview()
+
+    await flushPreviewRender()
+
+    expect(wrapper.get('.wj-preview-theme').attributes('style')).toContain('--wj-preview-image-box-shadow: var(--img-box-shadow);')
+  })
+
+  it('图片阴影关闭时预览根节点应覆盖图片阴影变量为 none', async () => {
+    markdownPreviewRuntimeState.store.config.markdown.imageShadow = false
+
+    const wrapper = mountMarkdownPreview()
+
+    await flushPreviewRender()
+
+    expect(wrapper.get('.wj-preview-theme').attributes('style')).toContain('--wj-preview-image-box-shadow: none;')
   })
 
   it('右键预览资源时会兼容 data-wj-resource-markdown-reference 并透传到 previewContextmenu 上下文', async () => {

--- a/wj-markdown-editor-web/src/components/editor/__tests__/markdownPreviewKeepAliveThemeRefresh.vitest.test.js
+++ b/wj-markdown-editor-web/src/components/editor/__tests__/markdownPreviewKeepAliveThemeRefresh.vitest.test.js
@@ -224,6 +224,7 @@ function createStore() {
       },
       markdown: {
         inlineCodeClickCopy: false,
+        imageShadow: true,
         typographer: false,
       },
     },

--- a/wj-markdown-editor-web/src/i18n/enUS.js
+++ b/wj-markdown-editor-web/src/i18n/enUS.js
@@ -182,6 +182,8 @@ export default {
       globalTheme: 'Global theme',
       codeTheme: 'Code theme',
       previewTheme: 'Preview theme',
+      previewImageShadow: 'Preview image shadow',
+      previewImageShadowTip: 'Controls image shadows in Markdown preview. PDF, PNG, and JPEG exports use the same effect.',
       previewWidth: 'Preview width',
       fontSize: 'Font size',
       editorPreviewPositionOption: {

--- a/wj-markdown-editor-web/src/i18n/zhCN.js
+++ b/wj-markdown-editor-web/src/i18n/zhCN.js
@@ -182,6 +182,8 @@ export default {
       globalTheme: '全局主题',
       codeTheme: '代码主题',
       previewTheme: '预览主题',
+      previewImageShadow: '预览图片阴影',
+      previewImageShadowTip: '控制 Markdown 预览中的图片阴影，导出 PDF、PNG、JPEG 时也会沿用该效果。',
       previewWidth: '预览宽度',
       fontSize: '字体大小',
       editorPreviewPositionOption: {

--- a/wj-markdown-editor-web/src/views/SettingView.vue
+++ b/wj-markdown-editor-web/src/views/SettingView.vue
@@ -495,6 +495,27 @@ function reset() {
               </a-select-option>
             </a-select>
           </a-descriptions-item>
+          <a-descriptions-item>
+            <template #label>
+              <div class="flex items-center gap-1">
+                <span>{{ $t('config.view.previewImageShadow') }}</span>
+                <a-tooltip placement="topRight" color="#1677ff" class="flex-shrink-0">
+                  <template #title>
+                    {{ $t('config.view.previewImageShadowTip') }}
+                  </template>
+                  <div class="i-tabler:info-circle font-size-4 op-50 hover:op-100" />
+                </a-tooltip>
+              </div>
+            </template>
+            <a-radio-group :value="config.markdown.imageShadow" button-style="solid" @update:value="value => submitSetPathMutation(['markdown', 'imageShadow'], value)">
+              <a-radio-button :value="true">
+                {{ $t('config.yes') }}
+              </a-radio-button>
+              <a-radio-button :value="false">
+                {{ $t('config.no') }}
+              </a-radio-button>
+            </a-radio-group>
+          </a-descriptions-item>
           <a-descriptions-item :label="$t('config.view.previewWidth')">
             <a-slider
               :value="config.previewWidth"

--- a/wj-markdown-editor-web/src/views/__tests__/settingViewImageShadowOption.test.js
+++ b/wj-markdown-editor-web/src/views/__tests__/settingViewImageShadowOption.test.js
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+
+import enUS from '../../i18n/enUS.js'
+import zhCN from '../../i18n/zhCN.js'
+
+const { test } = await import('node:test')
+
+function readSettingViewSource() {
+  return fs.readFileSync(new URL('../SettingView.vue', import.meta.url), 'utf8')
+}
+
+test('设置页必须提供预览图片阴影开关', () => {
+  const source = readSettingViewSource()
+
+  assert.equal(zhCN.config.view.previewImageShadow, '预览图片阴影')
+  assert.equal(
+    zhCN.config.view.previewImageShadowTip,
+    '控制 Markdown 预览中的图片阴影，导出 PDF、PNG、JPEG 时也会沿用该效果。',
+  )
+  assert.equal(enUS.config.view.previewImageShadow, 'Preview image shadow')
+  assert.equal(
+    enUS.config.view.previewImageShadowTip,
+    'Controls image shadows in Markdown preview. PDF, PNG, and JPEG exports use the same effect.',
+  )
+
+  assert.match(
+    source,
+    /config\.view\.previewImageShadow[\s\S]*?:value="config\.markdown\.imageShadow"[\s\S]*?submitSetPathMutation\(\['markdown', 'imageShadow'\], value\)/u,
+  )
+})


### PR DESCRIPTION
 ## 变更内容

  - 新增全局 Markdown 图片阴影配置 `markdown.imageShadow`
  - 设置页新增图片阴影开关
  - 默认值保持为开启，兼容旧版本已有图片阴影行为
  - 编辑页预览和独立预览实时应用开关
  - PDF、PNG、JPEG 导出沿用相同的图片阴影效果
  - 旧配置缺少该字段时自动补充默认值
  - 新增配置 Schema、修复逻辑和预览组件测试

  ## 产品行为

  该选项是全局开关，同时影响：

  - Markdown 编辑页预览
  - 独立预览页
  - PDF 导出
  - PNG 导出
  - JPEG 导出